### PR TITLE
feat: make ground electrode location optional #94

### DIFF
--- a/schemas/artemis/activities/acquisition/acquisition_schema.jsonld
+++ b/schemas/artemis/activities/acquisition/acquisition_schema.jsonld
@@ -26,6 +26,7 @@
             "items/online_reference_type.jsonld",
             "items/alternatives_to_reference.jsonld",
             "items/online_reference_type_other.jsonld",
+            "items/ground_electrode_exists.jsonld",
             "items/location_ground.jsonld",
             "items/online_reference_VEOG.jsonld",
             "items/online_reference_VEOG_other.jsonld",
@@ -197,12 +198,24 @@
                 ]
             },
             {
+                "variableName": "ground_electrode_exists",
+                "isAbout": "items/ground_electrode_exists.jsonld",
+                "prefLabel": {
+                    "en": "ground electrode exists"
+                },
+                "isVis": "online_reference_exists == 1",
+                "requiredValue": false,
+                "allow": [
+                    "reproschema:Skipped"
+                ]
+            },
+            {
                 "variableName": "location_ground",
                 "isAbout": "items/location_ground.jsonld",
                 "prefLabel": {
                     "en": "location ground"
                 },
-                "isVis": "online_reference_exists == 1",
+                "isVis": "ground_electrode_exists == 1",
                 "requiredValue": false,
                 "allow": [
                     "reproschema:Skipped"

--- a/schemas/artemis/activities/acquisition/items/ground_electrode_exists.jsonld
+++ b/schemas/artemis/activities/acquisition/items/ground_electrode_exists.jsonld
@@ -1,0 +1,23 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc4/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "ground_electrode_exists.jsonld",
+    "schemaVersion": "1.0.0-rc4",
+    "version": "0.0.1",
+    "prefLabel": {
+        "en": "ground electrode exists"
+    },
+    "description": "ground electrode exists",
+    "ui": {
+        "inputType": "radio"
+    },
+    "question": {
+        "en": "4.12 - Was a ground electrode used?"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "choices": "https://raw.githubusercontent.com/ohbm/cobidas_schema/master/response_options/boolean.jsonld",
+        "minValue": 0,
+        "maxValue": 0
+    }
+}


### PR DESCRIPTION
Fixes #94

This PR introduces a change to the acquisition schema to make the "location of the ground electrode" question optional.

Changes:

Added a new ground_electrode_exists item ("Was a ground electrode used?").
Updated 
acquisition_schema.jsonld
 to include this new item.
Modified the visibility logic for location_ground: it now depends on ground_electrode_exists == 1 instead of directly on online_reference_exists. This ensures users are first asked if a ground electrode was used before being asked for its location.
Verification:

Verified that the new item appears in the schema order.
Verified that the visibility logic mirrors the behavior of the reference electrode questions.