### PR TITLE
Feat issue 2 order of operations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true

--- a/schemas/artemis/activities/acquisition/acquisition_schema.jsonld
+++ b/schemas/artemis/activities/acquisition/acquisition_schema.jsonld
@@ -26,6 +26,7 @@
             "items/online_reference_type.jsonld",
             "items/alternatives_to_reference.jsonld",
             "items/online_reference_type_other.jsonld",
+            "items/ground_electrode_exists.jsonld",
             "items/location_ground.jsonld",
             "items/online_reference_VEOG.jsonld",
             "items/online_reference_VEOG_other.jsonld",
@@ -197,12 +198,24 @@
                 ]
             },
             {
+                "variableName": "ground_electrode_exists",
+                "isAbout": "items/ground_electrode_exists.jsonld",
+                "prefLabel": {
+                    "en": "ground electrode exists"
+                },
+                "isVis": "online_reference_exists == 1",
+                "requiredValue": false,
+                "allow": [
+                    "reproschema:Skipped"
+                ]
+            },
+            {
                 "variableName": "location_ground",
                 "isAbout": "items/location_ground.jsonld",
                 "prefLabel": {
                     "en": "location ground"
                 },
-                "isVis": "online_reference_exists == 1",
+                "isVis": "ground_electrode_exists == 1",
                 "requiredValue": false,
                 "allow": [
                     "reproschema:Skipped"

--- a/schemas/artemis/activities/acquisition/items/ground_electrode_exists.jsonld
+++ b/schemas/artemis/activities/acquisition/items/ground_electrode_exists.jsonld
@@ -1,0 +1,23 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc4/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "ground_electrode_exists.jsonld",
+    "schemaVersion": "1.0.0-rc4",
+    "version": "0.0.1",
+    "prefLabel": {
+        "en": "ground electrode exists"
+    },
+    "description": "ground electrode exists",
+    "ui": {
+        "inputType": "radio"
+    },
+    "question": {
+        "en": "4.12 - Was a ground electrode used?"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "choices": "https://raw.githubusercontent.com/ohbm/cobidas_schema/master/response_options/boolean.jsonld",
+        "minValue": 0,
+        "maxValue": 0
+    }
+}

--- a/schemas/artemis/activities/hardware/hardware_schema.jsonld
+++ b/schemas/artemis/activities/hardware/hardware_schema.jsonld
@@ -29,6 +29,7 @@
             "items/electrode_location_naming_convention.jsonld",
             "items/ten-twenty_version.jsonld",
             "items/number_EEG_electrodes.jsonld",
+            "items/included_electrodes.jsonld",
             "items/link_electrode_scheme.jsonld",
             "items/non-EEG_electrodes_exists.jsonld",
             "items/non-EEG_electrodes.jsonld",
@@ -221,6 +222,18 @@
                     "en": "number EEG electrodes"
                 },
                 "isVis": true,
+                "requiredValue": false,
+                "allow": [
+                    "reproschema:Skipped"
+                ]
+            },
+            {
+                "variableName": "included_electrodes",
+                "isAbout": "items/included_electrodes.jsonld",
+                "prefLabel": {
+                    "en": "included electrodes"
+                },
+                "isVis": "electrode_location_naming_convention == 0",
                 "requiredValue": false,
                 "allow": [
                     "reproschema:Skipped"

--- a/schemas/artemis/activities/hardware/items/included_electrodes.jsonld
+++ b/schemas/artemis/activities/hardware/items/included_electrodes.jsonld
@@ -1,0 +1,505 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc4/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "included_electrodes.jsonld",
+    "schemaVersion": "1.0.0-rc4",
+    "version": "0.0.1",
+    "prefLabel": {
+        "en": "included electrodes"
+    },
+    "description": "included electrodes",
+    "ui": {
+        "inputType": "select"
+    },
+    "question": {
+        "en": "3.14 - Which electrodes were used in the recording? (Select all that apply)"
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "multipleChoice": true,
+        "choices": [
+            {
+                "name": {
+                    "en": "Fp1"
+                },
+                "value": 0
+            },
+            {
+                "name": {
+                    "en": "Fpz"
+                },
+                "value": 1
+            },
+            {
+                "name": {
+                    "en": "Fp2"
+                },
+                "value": 2
+            },
+            {
+                "name": {
+                    "en": "AF9"
+                },
+                "value": 3
+            },
+            {
+                "name": {
+                    "en": "AF7"
+                },
+                "value": 4
+            },
+            {
+                "name": {
+                    "en": "AF5"
+                },
+                "value": 5
+            },
+            {
+                "name": {
+                    "en": "AF3"
+                },
+                "value": 6
+            },
+            {
+                "name": {
+                    "en": "AF1"
+                },
+                "value": 7
+            },
+            {
+                "name": {
+                    "en": "AFz"
+                },
+                "value": 8
+            },
+            {
+                "name": {
+                    "en": "AF2"
+                },
+                "value": 9
+            },
+            {
+                "name": {
+                    "en": "AF4"
+                },
+                "value": 10
+            },
+            {
+                "name": {
+                    "en": "AF6"
+                },
+                "value": 11
+            },
+            {
+                "name": {
+                    "en": "AF8"
+                },
+                "value": 12
+            },
+            {
+                "name": {
+                    "en": "AF10"
+                },
+                "value": 13
+            },
+            {
+                "name": {
+                    "en": "F9"
+                },
+                "value": 14
+            },
+            {
+                "name": {
+                    "en": "F7"
+                },
+                "value": 15
+            },
+            {
+                "name": {
+                    "en": "F5"
+                },
+                "value": 16
+            },
+            {
+                "name": {
+                    "en": "F3"
+                },
+                "value": 17
+            },
+            {
+                "name": {
+                    "en": "F1"
+                },
+                "value": 18
+            },
+            {
+                "name": {
+                    "en": "Fz"
+                },
+                "value": 19
+            },
+            {
+                "name": {
+                    "en": "F2"
+                },
+                "value": 20
+            },
+            {
+                "name": {
+                    "en": "F4"
+                },
+                "value": 21
+            },
+            {
+                "name": {
+                    "en": "F6"
+                },
+                "value": 22
+            },
+            {
+                "name": {
+                    "en": "F8"
+                },
+                "value": 23
+            },
+            {
+                "name": {
+                    "en": "F10"
+                },
+                "value": 24
+            },
+            {
+                "name": {
+                    "en": "FT9"
+                },
+                "value": 25
+            },
+            {
+                "name": {
+                    "en": "FT7"
+                },
+                "value": 26
+            },
+            {
+                "name": {
+                    "en": "FC5"
+                },
+                "value": 27
+            },
+            {
+                "name": {
+                    "en": "FC3"
+                },
+                "value": 28
+            },
+            {
+                "name": {
+                    "en": "FC1"
+                },
+                "value": 29
+            },
+            {
+                "name": {
+                    "en": "FCz"
+                },
+                "value": 30
+            },
+            {
+                "name": {
+                    "en": "FC2"
+                },
+                "value": 31
+            },
+            {
+                "name": {
+                    "en": "FC4"
+                },
+                "value": 32
+            },
+            {
+                "name": {
+                    "en": "FC6"
+                },
+                "value": 33
+            },
+            {
+                "name": {
+                    "en": "FT8"
+                },
+                "value": 34
+            },
+            {
+                "name": {
+                    "en": "FT10"
+                },
+                "value": 35
+            },
+            {
+                "name": {
+                    "en": "T9"
+                },
+                "value": 36
+            },
+            {
+                "name": {
+                    "en": "T7"
+                },
+                "value": 37
+            },
+            {
+                "name": {
+                    "en": "C5"
+                },
+                "value": 38
+            },
+            {
+                "name": {
+                    "en": "C3"
+                },
+                "value": 39
+            },
+            {
+                "name": {
+                    "en": "C1"
+                },
+                "value": 40
+            },
+            {
+                "name": {
+                    "en": "Cz"
+                },
+                "value": 41
+            },
+            {
+                "name": {
+                    "en": "C2"
+                },
+                "value": 42
+            },
+            {
+                "name": {
+                    "en": "C4"
+                },
+                "value": 43
+            },
+            {
+                "name": {
+                    "en": "C6"
+                },
+                "value": 44
+            },
+            {
+                "name": {
+                    "en": "T8"
+                },
+                "value": 45
+            },
+            {
+                "name": {
+                    "en": "T10"
+                },
+                "value": 46
+            },
+            {
+                "name": {
+                    "en": "TP9"
+                },
+                "value": 47
+            },
+            {
+                "name": {
+                    "en": "TP7"
+                },
+                "value": 48
+            },
+            {
+                "name": {
+                    "en": "CP5"
+                },
+                "value": 49
+            },
+            {
+                "name": {
+                    "en": "CP3"
+                },
+                "value": 50
+            },
+            {
+                "name": {
+                    "en": "CP1"
+                },
+                "value": 51
+            },
+            {
+                "name": {
+                    "en": "CPz"
+                },
+                "value": 52
+            },
+            {
+                "name": {
+                    "en": "CP2"
+                },
+                "value": 53
+            },
+            {
+                "name": {
+                    "en": "CP4"
+                },
+                "value": 54
+            },
+            {
+                "name": {
+                    "en": "CP6"
+                },
+                "value": 55
+            },
+            {
+                "name": {
+                    "en": "TP8"
+                },
+                "value": 56
+            },
+            {
+                "name": {
+                    "en": "TP10"
+                },
+                "value": 57
+            },
+            {
+                "name": {
+                    "en": "P9"
+                },
+                "value": 58
+            },
+            {
+                "name": {
+                    "en": "P7"
+                },
+                "value": 59
+            },
+            {
+                "name": {
+                    "en": "P5"
+                },
+                "value": 60
+            },
+            {
+                "name": {
+                    "en": "P3"
+                },
+                "value": 61
+            },
+            {
+                "name": {
+                    "en": "P1"
+                },
+                "value": 62
+            },
+            {
+                "name": {
+                    "en": "Pz"
+                },
+                "value": 63
+            },
+            {
+                "name": {
+                    "en": "P2"
+                },
+                "value": 64
+            },
+            {
+                "name": {
+                    "en": "P4"
+                },
+                "value": 65
+            },
+            {
+                "name": {
+                    "en": "P6"
+                },
+                "value": 66
+            },
+            {
+                "name": {
+                    "en": "P8"
+                },
+                "value": 67
+            },
+            {
+                "name": {
+                    "en": "P10"
+                },
+                "value": 68
+            },
+            {
+                "name": {
+                    "en": "PO9"
+                },
+                "value": 69
+            },
+            {
+                "name": {
+                    "en": "PO7"
+                },
+                "value": 70
+            },
+            {
+                "name": {
+                    "en": "PO3"
+                },
+                "value": 71
+            },
+            {
+                "name": {
+                    "en": "POz"
+                },
+                "value": 72
+            },
+            {
+                "name": {
+                    "en": "PO4"
+                },
+                "value": 73
+            },
+            {
+                "name": {
+                    "en": "PO8"
+                },
+                "value": 74
+            },
+            {
+                "name": {
+                    "en": "PO10"
+                },
+                "value": 75
+            },
+            {
+                "name": {
+                    "en": "O1"
+                },
+                "value": 76
+            },
+            {
+                "name": {
+                    "en": "Oz"
+                },
+                "value": 77
+            },
+            {
+                "name": {
+                    "en": "O2"
+                },
+                "value": 78
+            },
+            {
+                "name": {
+                    "en": "Iz"
+                },
+                "value": 79
+            }
+        ],
+        "minValue": 0,
+        "maxValue": 79
+    }
+}

--- a/schemas/artemis/activities/preprocessing/items/preprocessing_order.jsonld
+++ b/schemas/artemis/activities/preprocessing/items/preprocessing_order.jsonld
@@ -9,9 +9,59 @@
     },
     "description": "preprocessing order",
     "ui": {
-        "inputType": "textarea"
+        "inputType": "select",
+        "multiple": true
     },
     "question": {
-        "en": "5.109 - Describe order of all pre-processing steps described here in a way that allows replication."
+        "en": "5.109 - Select the order of all pre-processing steps described here (select all that apply)."
+    },
+    "responseOptions": {
+        "valueType": "xsd:integer",
+        "choices": [
+            {
+                "name": {
+                    "en": "Filtering"
+                },
+                "value": 0
+            },
+            {
+                "name": {
+                    "en": "Downsampling"
+                },
+                "value": 1
+            },
+            {
+                "name": {
+                    "en": "Re-referencing"
+                },
+                "value": 2
+            },
+            {
+                "name": {
+                    "en": "Artifact Removal"
+                },
+                "value": 3
+            },
+            {
+                "name": {
+                    "en": "Epoching"
+                },
+                "value": 4
+            },
+            {
+                "name": {
+                    "en": "Baseline Correction"
+                },
+                "value": 5
+            },
+            {
+                "name": {
+                    "en": "Other"
+                },
+                "value": 6
+            }
+        ],
+        "minValue": 0,
+        "maxValue": 6
     }
 }

--- a/schemas/artemis/activities/preprocessing/items/preprocessing_order_other.jsonld
+++ b/schemas/artemis/activities/preprocessing/items/preprocessing_order_other.jsonld
@@ -1,0 +1,21 @@
+{
+    "@context": "https://raw.githubusercontent.com/ReproNim/reproschema/1.0.0-rc4/contexts/generic",
+    "@type": "reproschema:Field",
+    "@id": "preprocessing_order_other.jsonld",
+    "schemaVersion": "1.0.0-rc4",
+    "version": "0.0.1",
+    "prefLabel": {
+        "en": "preprocessing order other"
+    },
+    "description": "preprocessing order other",
+    "ui": {
+        "inputType": "textarea"
+    },
+    "question": {
+        "en": "5.110 - Describe the complex procedure or other steps not listed."
+    },
+    "responseOptions": {
+        "valueType": "xsd:string",
+        "maxLength": 300
+    }
+}

--- a/schemas/artemis/activities/preprocessing/preprocessing_schema.jsonld
+++ b/schemas/artemis/activities/preprocessing/preprocessing_schema.jsonld
@@ -122,7 +122,8 @@
             "items/baseline_end.jsonld",
             "items/baseline_method.jsonld",
             "items/baseline_other_method_details.jsonld",
-            "items/preprocessing_order.jsonld"
+            "items/preprocessing_order.jsonld",
+            "items/preprocessing_order_other.jsonld"
         ],
         "addProperties": [
             {
@@ -1428,6 +1429,18 @@
                     "en": "preprocessing order"
                 },
                 "isVis": true,
+                "requiredValue": false,
+                "allow": [
+                    "reproschema:Skipped"
+                ]
+            },
+            {
+                "variableName": "preprocessing_order_other",
+                "isAbout": "items/preprocessing_order_other.jsonld",
+                "prefLabel": {
+                    "en": "preprocessing order other"
+                },
+                "isVis": "preprocessing_order.includes(6)",
                 "requiredValue": false,
                 "allow": [
                     "reproschema:Skipped"


### PR DESCRIPTION
 Fixes #2

Improved the reporting of the "order of operations" during preprocessing. Previously, this was an open-ended text area. Per issue discussion (and "future goal" comments), this has been converted to a multi-select list of standard steps, with an "Other" option for complex procedures.

Changes:

Modified 
schemas/artemis/activities/preprocessing/items/preprocessing_order.jsonld
: Changed input type to select (multiple) and added choices (Filtering, Downsampling, Re-referencing, Artifact Removal, Epoching, Baseline Correction, Other).
Added 
schemas/artemis/activities/preprocessing/items/preprocessing_order_other.jsonld
: New text area for describing unlisted steps (visible only when "Other" is selected).
Updated 
schemas/artemis/activities/preprocessing/preprocessing_schema.jsonld
: Added the new item to the order and defined visibility logic.
Verification:

Verified JSON-LD structure and isVis logic (preprocessing_order.includes(6)).