### PR TITLE
Fix: Suppress gdown UserWarning by enabling fuzzy extraction

### DIFF
--- a/convert_table/src/download.py
+++ b/convert_table/src/download.py
@@ -14,8 +14,7 @@ def main():
 
         URL = f"https://docs.google.com/spreadsheets/d/{google_id}/export?format=tsv&gid={sheet_ids()[id]}"
 
-        gdown.download(URL, output=str(output_dir.joinpath(f"{id}.tsv")))
-
+        gdown.download(URL, output=str(output_dir.joinpath(f"{id}.tsv")), fuzzy=True)
 
 def sheet_ids():
 


### PR DESCRIPTION
### Problem
When running `python convert_table/src/download.py`, `gdown` throws a `UserWarning` because the URL format for Google Sheets export is detected as a file link rather than a folder, prompting the user to try the `--fuzzy` option.

### Solution
Added `fuzzy=True` to the `gdown.download` call in `convert_table/src/download.py`. This explicitly tells `gdown` to handle the URL extraction correctly, silencing the warning and ensuring cleaner output logs.

### Verification
Ran the download script locally:
**Before:**
`UserWarning: You specified a Google Drive link that is not the correct link...`

**After:**
`Downloading...` (Clean output, no warnings)