### PR TITLE
Docs/video tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ Read more about the rationale for this project and the design principles we go b
 1. Have a look at our **[project on OSF](https://osf.io/pvrn6/)**.
 2. **Talks and slides** are available [HERE](https://osf.io/ncav8/).
 3. See [CONTRIBUTING.md](src/CONTRIBUTING.md) for information on how to contribute.
+## Google Spreadsheet Backup
+
+The ARTEM-IS Google Spreadsheet is automatically backed up during the generation
+of the **linear version table**.
+
+The exported linear table serves as a static snapshot of the spreadsheet at the
+time of generation, ensuring reproducibility and offline availability of the
+data.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ of the **linear version table**.
 The exported linear table serves as a static snapshot of the spreadsheet at the
 time of generation, ensuring reproducibility and offline availability of the
 data.
+## Video Tutorial
+
+A video tutorial introducing ARTEM-IS and demonstrating its main features is
+available on YouTube:
+
+▶️ https://youtu.be/80S64ZBuV80?si=E_fcoa4Qs91U3Aka
+
+This tutorial provides a step-by-step overview of how to use the ARTEM-IS web
+application.
+


### PR DESCRIPTION
This PR adds a link to the ARTEM-IS YouTube video tutorial in the documentation.

The tutorial provides an overview of the web application and its main features. Future integration into the web-app itself can be considered separately.

Closes #96.
